### PR TITLE
[FEATURE] |  Add HomeCubit for managing product state

### DIFF
--- a/lib/Features/home/presentation/view_model/home_cubit/home_cubit.dart
+++ b/lib/Features/home/presentation/view_model/home_cubit/home_cubit.dart
@@ -1,0 +1,22 @@
+import 'package:bloc/bloc.dart';
+
+import '../../../data/models/product_model.dart';
+import '../../../data/repos/home_repo.dart';
+
+part 'home_state.dart';
+
+class HomeCubit extends Cubit<HomeState> {
+  HomeCubit({required this.homeRepo}) : super(HomeInitialState());
+
+  final HomeRepo homeRepo;
+
+  Future<void> fetchProducts() async {
+    emit(ProductLoadingState());
+    final result = await homeRepo.fetchProducts();
+    result.fold((l) {
+      emit(ProductLoadedFailureState(message: l.errorMessage));
+    }, (r) {
+      emit(ProductLoadedState(products: r));
+    });
+  }
+}

--- a/lib/Features/home/presentation/view_model/home_cubit/home_state.dart
+++ b/lib/Features/home/presentation/view_model/home_cubit/home_state.dart
@@ -1,0 +1,23 @@
+part of 'home_cubit.dart';
+
+abstract class HomeState {}
+
+final class HomeInitialState extends HomeState {}
+
+final class ProductLoadingState extends HomeState {}
+
+final class ProductLoadedState extends HomeState {
+  final List<ProductModel> products;
+
+  ProductLoadedState({
+    required this.products,
+  });
+}
+
+final class ProductLoadedFailureState extends HomeState {
+  final String message;
+
+  ProductLoadedFailureState({
+    required this.message,
+  });
+}


### PR DESCRIPTION
feat: add HomeCubit for managing product state

- Created HomeCubit to handle the business logic for fetching products.
- Added states to handle product loading, success, and failure.
- Integrated the cubit with HomeRepo to fetch products from the API.