### PR TITLE
[FEATURE] | Add ErrorScreen widget and integrate BLoC for fetching and displaying products.

### DIFF
--- a/lib/Core/shared_widget/error_screen.dart
+++ b/lib/Core/shared_widget/error_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class ErrorScreen extends StatelessWidget {
+  const ErrorScreen({
+    super.key,
+    required this.errorMessage,
+    this.onPressed,
+  });
+
+  final String errorMessage;
+  final void Function()? onPressed;
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Icon(
+          Icons.error_outline,
+          size: 50.w,
+          color: Colors.red,
+        ),
+        SizedBox(height: 10.h),
+        Text(
+          'Oops! Something went wrong.',
+          style: TextStyle(
+            fontSize: 16.sp,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        SizedBox(height: 10.h),
+        Text(
+          errorMessage,
+          style: TextStyle(
+            fontSize: 14.sp,
+            color: Colors.grey,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        SizedBox(height: 20.h),
+        ElevatedButton(
+          onPressed: onPressed,
+          child: Text(
+            'Retry',
+            style: TextStyle(fontSize: 14.sp),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/Features/home/presentation/view/home_screen.dart
+++ b/lib/Features/home/presentation/view/home_screen.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../../Core/utils/dependency_injection.dart';
+import '../../data/repos/home_repo_implementation.dart';
+import '../view_model/home_cubit/home_cubit.dart';
 import 'widgets/home_body.dart';
 
 class HomeScreen extends StatelessWidget {
@@ -9,7 +13,12 @@ class HomeScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return SafeArea(
       child: Scaffold(
-        body: HomeBody(),
+        body: BlocProvider(
+          create: (context) => HomeCubit(
+            homeRepo: serviceLocator<HomeRepoImplementation>(),
+          )..fetchProducts(),
+          child: HomeBody(),
+        ),
       ),
     );
   }

--- a/lib/Features/home/presentation/view/widgets/product_list_view.dart
+++ b/lib/Features/home/presentation/view/widgets/product_list_view.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
+import '../../../../../Core/shared_widget/error_screen.dart';
+import '../../../../../Core/utils/app_logger.dart';
+import '../../view_model/home_cubit/home_cubit.dart';
 import 'product_list_view_item.dart';
 
 class ProductListView extends StatelessWidget {
@@ -8,13 +12,32 @@ class ProductListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Wrap(
-      runSpacing: 10.h,
-      spacing: 7.w,
-      children: List.generate(
-        8,
-        (index) => ProductListViewItem(),
-      ),
+    return BlocConsumer<HomeCubit, HomeState>(
+      listener: (context, state) {},
+      builder: (context, state) {
+        if (state is ProductLoadedState) {
+          return Wrap(
+            runSpacing: 10.h,
+            spacing: 7.w,
+            children: List.generate(
+              state.products.length,
+              (index) => ProductListViewItem(
+                productModel: state.products[index],
+              ),
+            ),
+          );
+        } else if (state is ProductLoadedFailureState) {
+          AppLogger.print("Failure State Message: ${state.message}");
+          return ErrorScreen(
+            errorMessage: state.message,
+            onPressed: () => context.read<HomeCubit>().fetchProducts(),
+          );
+        } else {
+          return Center(
+            child: CircularProgressIndicator(),
+          );
+        }
+      },
     );
   }
 }

--- a/lib/Features/home/presentation/view/widgets/product_list_view_item.dart
+++ b/lib/Features/home/presentation/view/widgets/product_list_view_item.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import '../../../../../Core/utils/app_colors.dart';
+import '../../../data/models/product_model.dart';
 import 'add_to_cart_button.dart';
 import 'add_to_fav_button.dart';
 import 'product_list_view_item_body.dart';
@@ -9,7 +10,10 @@ import 'product_list_view_item_body.dart';
 class ProductListViewItem extends StatelessWidget {
   const ProductListViewItem({
     super.key,
+    required this.productModel,
   });
+
+  final ProductModel productModel;
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +36,9 @@ class ProductListViewItem extends StatelessWidget {
                 width: 3.r,
               ),
             ),
-            child: ProductListViewItemBody(),
+            child: ProductListViewItemBody(
+              productModel: productModel,
+            ),
           ),
           AddToCartButton(),
           AddToFavButton(),

--- a/lib/Features/home/presentation/view/widgets/product_list_view_item_body.dart
+++ b/lib/Features/home/presentation/view/widgets/product_list_view_item_body.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import '../../../../../Core/utils/app_styles.dart';
+import '../../../data/models/product_model.dart';
 import 'product_image.dart';
 import 'product_price.dart';
 import 'product_rating.dart';
@@ -9,7 +10,10 @@ import 'product_rating.dart';
 class ProductListViewItemBody extends StatelessWidget {
   const ProductListViewItemBody({
     super.key,
+    required this.productModel,
   });
+
+  final ProductModel productModel;
 
   @override
   Widget build(BuildContext context) {
@@ -17,30 +21,29 @@ class ProductListViewItemBody extends StatelessWidget {
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         ProductImage(
-          urlImage:
-              'https://fakestoreapi.com/img/71-3HjGNDUL._AC_SY879._SX._UX._SY._UY_.jpg',
+          urlImage: productModel.image,
         ),
         Padding(
           padding: EdgeInsets.only(top: 5.h, bottom: 1.h),
           child: Text(
-            'Mens Casual Premium Slim Fit T-Shirts ',
+            productModel.title,
             style: AppStyles.textStyle16,
             maxLines: 1,
             overflow: TextOverflow.clip,
           ),
         ),
         Text(
-          'Slim-fitting style, contrast raglan long sleeve, three-button henley placket, light weight & soft fabric for breathable and comfortable wearing. And Solid stitched shirts with round neck made for durability and a great fit for casual fashion wear and diehard baseball fans. The Henley style round neckline includes a three-button placket.',
+          productModel.description,
           style: AppStyles.textStyle16,
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
         Padding(
           padding: EdgeInsets.only(bottom: 11.h, top: 8.h),
-          child: ProductPrice(price: 22.3),
+          child: ProductPrice(price: productModel.price),
         ),
         ProductRating(
-          rating: 4.1,
+          rating: productModel.rating.rate,
         ),
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
+import 'package:elevate/Core/utils/dependency_injection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 import 'Features/home/presentation/view/home_screen.dart';
 
 void main() {
+  setup();
   runApp(const Elevate());
 }
 


### PR DESCRIPTION
feat: add ErrorScreen widget and integrate BLoC for fetching and displaying products

- Added ErrorScreen widget in Core/shared_widget folder for error handling.
- Updated HomeScreen to use BlocProvider for managing HomeCubit.
- Added BlocConsumer in ProductListView to listen to state changes and display products.
- Modified ProductListViewItem and ProductListViewItemBody to accept and display ProductModel data.
- Enhanced UI to reflect loading, success, and failure states of product fetching.